### PR TITLE
Fixes loading models, and saving/loading as Tensorflow Lite models

### DIFF
--- a/tfkan/layers/convolution.py
+++ b/tfkan/layers/convolution.py
@@ -189,7 +189,7 @@ class Conv2DKAN(ConvolutionKAN):
 
     def _check_and_reshape_inputs(self, inputs):
         shape = tf.shape(inputs)
-        ndim = 4#len(shape)
+        ndim = tf.size(shape) # 4
         try:
             assert ndim == 4
         except AssertionError:
@@ -245,7 +245,7 @@ class Conv3DKAN(ConvolutionKAN):
     
     def _check_and_reshape_inputs(self, inputs):
         shape = tf.shape(inputs)
-        ndim = 5#len(shape)
+        ndim = tf.size(shape) # 5
         try:
             assert ndim == 5
         except AssertionError:
@@ -300,7 +300,7 @@ class Conv1DKAN(ConvolutionKAN):
 
     def _check_and_reshape_inputs(self, inputs):
         shape = tf.shape(inputs)
-        ndim = 3#len(shape)
+        ndim = tf.size(shape) # 3
         try:
             assert ndim == 3
         except AssertionError:

--- a/tfkan/layers/convolution.py
+++ b/tfkan/layers/convolution.py
@@ -157,6 +157,8 @@ class ConvolutionKAN(Layer, LayerKAN):
     
     @classmethod
     def from_config(cls, config):
+        if "rank" in config:
+            rank = config.pop("rank")
         return cls(**config)
 
 class Conv2DKAN(ConvolutionKAN):
@@ -187,7 +189,7 @@ class Conv2DKAN(ConvolutionKAN):
 
     def _check_and_reshape_inputs(self, inputs):
         shape = tf.shape(inputs)
-        ndim = len(shape)
+        ndim = 4#len(shape)
         try:
             assert ndim == 4
         except AssertionError:
@@ -243,7 +245,7 @@ class Conv3DKAN(ConvolutionKAN):
     
     def _check_and_reshape_inputs(self, inputs):
         shape = tf.shape(inputs)
-        ndim = len(shape)
+        ndim = 5#len(shape)
         try:
             assert ndim == 5
         except AssertionError:
@@ -298,7 +300,7 @@ class Conv1DKAN(ConvolutionKAN):
 
     def _check_and_reshape_inputs(self, inputs):
         shape = tf.shape(inputs)
-        ndim = len(shape)
+        ndim = 3#len(shape)
         try:
             assert ndim == 3
         except AssertionError:

--- a/tfkan/layers/convolution.py
+++ b/tfkan/layers/convolution.py
@@ -188,17 +188,19 @@ class Conv2DKAN(ConvolutionKAN):
         super(Conv2DKAN, self).__init__(rank=2, filters=filters, kernel_size=kernel_size, strides=strides, padding=padding, use_bias=use_bias, kan_kwargs=kan_kwargs, **kwargs)
 
     def _check_and_reshape_inputs(self, inputs):
-        shape = tf.shape(inputs)
-        ndim = tf.size(shape) # 4
-        try:
-            assert ndim == 4
-        except AssertionError:
-            raise ValueError(f"expected min_ndim=4, found ndim={ndim}. Full shape received: {shape}")
-
-        try:
-            assert inputs.shape[-1] == self._in_channels
-        except AssertionError:
-            raise ValueError(f"expected last dimension of inputs to be {self._in_channels}, found {shape[-1]}")
+        shape = inputs.get_shape()
+        ndim = len(shape)
+        
+        # The input should have (batch_size, spatial, channels)
+        tf.debugging.assert_equal(ndim,
+                                  4,
+                                  f"Expected min_ndim=4, found ndim={ndim}. Full shape received: {shape}.",
+                                  )
+        
+        tf.debugging.assert_equal(inputs.shape[-1],
+                                  self._in_channels,
+                                  f"Expected last dimension of inputs to be {self._in_channels}, found {shape[-1]}",
+        )
         
         # reshape the inputs into patches
         # so we can transform the convolution into a dense layer
@@ -244,17 +246,19 @@ class Conv3DKAN(ConvolutionKAN):
         super(Conv3DKAN, self).__init__(rank=3, filters=filters, kernel_size=kernel_size, strides=strides, padding=padding, use_bias=use_bias, kan_kwargs=kan_kwargs, **kwargs)
     
     def _check_and_reshape_inputs(self, inputs):
-        shape = tf.shape(inputs)
-        ndim = tf.size(shape) # 5
-        try:
-            assert ndim == 5
-        except AssertionError:
-            raise ValueError(f"expected min_ndim=5, found ndim={ndim}. Full shape received: {shape}")
-
-        try:
-            assert inputs.shape[-1] == self._in_channels
-        except AssertionError:
-            raise ValueError(f"expected last dimension of inputs to be {self._in_channels}, found {shape[-1]}")
+        shape = inputs.get_shape()
+        ndim = len(shape)
+        
+        # The input should have (batch_size, spatial, channels)
+        tf.debugging.assert_equal(ndim,
+                                  5,
+                                  f"Expected min_ndim=5, found ndim={ndim}. Full shape received: {shape}.",
+                                  )
+        
+        tf.debugging.assert_equal(inputs.shape[-1],
+                                  self._in_channels,
+                                  f"Expected last dimension of inputs to be {self._in_channels}, found {shape[-1]}",
+        )
         
         # reshape the inputs into patches
         # so we can transform the convolution into a dense layer
@@ -299,17 +303,19 @@ class Conv1DKAN(ConvolutionKAN):
         super(Conv1DKAN, self).__init__(rank=1, filters=filters, kernel_size=kernel_size, strides=strides, padding=padding, use_bias=use_bias, kan_kwargs=kan_kwargs, **kwargs)
 
     def _check_and_reshape_inputs(self, inputs):
-        shape = tf.shape(inputs)
-        ndim = tf.size(shape) # 3
-        try:
-            assert ndim == 3
-        except AssertionError:
-            raise ValueError(f"expected min_ndim=3, found ndim={ndim}. Full shape received: {shape}")
-
-        try:
-            assert inputs.shape[-1] == self._in_channels
-        except AssertionError:
-            raise ValueError(f"expected last dimension of inputs to be {self._in_channels}, found {shape[-1]}")
+        shape = inputs.get_shape()
+        ndim = len(shape)
+        
+        # The input should have (batch_size, spatial, channels)
+        tf.debugging.assert_equal(ndim,
+                                  3,
+                                  f"Expected min_ndim=3, found ndim={ndim}. Full shape received: {shape}.",
+                                  )
+        
+        tf.debugging.assert_equal(inputs.shape[-1],
+                                  self._in_channels,
+                                  f"Expected last dimension of inputs to be {self._in_channels}, found {shape[-1]}",
+        )
         
         # reshape the inputs into patches
         # so we can transform the convolution into a dense layer

--- a/tfkan/layers/dense.py
+++ b/tfkan/layers/dense.py
@@ -122,7 +122,7 @@ class DenseKAN(Layer, LayerKAN):
     
     def _check_and_reshape_inputs(self, inputs):
         shape = tf.shape(inputs)
-        ndim = 2#len(shape)
+        ndim = tf.size(shape)
         try:
             assert ndim >= 2
         except AssertionError:

--- a/tfkan/layers/dense.py
+++ b/tfkan/layers/dense.py
@@ -121,20 +121,21 @@ class DenseKAN(Layer, LayerKAN):
         return spline_out
     
     def _check_and_reshape_inputs(self, inputs):
-        shape = tf.shape(inputs)
-        ndim = tf.size(shape)
-        try:
-            assert ndim >= 2
-        except AssertionError:
-            raise ValueError(f"expected min_ndim=2, found ndim={ndim}. Full shape received: {shape}")
-
-        try:
-            assert inputs.shape[-1] == self.in_size
-        except AssertionError:
-            raise ValueError(f"expected last dimension of inputs to be {self.in_size}, found {shape[-1]}")
+        shape = inputs.get_shape()
+        ndim = len(shape)
         
+        tf.debugging.assert_greater_equal(ndim,
+                                          2,
+                                          f"Expected min_ndim=2, found ndim={ndim}. Full shape received: {shape}"
+                                          )
+        
+        tf.debugging.assert_equal(inputs.shape[-1],
+                                  self.in_size,
+                                  f"Expected last dimension of inputs to be {self.in_size}, found {shape[-1]}."
+        )
+        
+        orig_shape = tf.shape(inputs)[:-1]
         # reshape the inputs to (-1, in_size)
-        orig_shape = shape[:-1]
         inputs = tf.reshape(inputs, (-1, self.in_size))
 
         return inputs, orig_shape

--- a/tfkan/layers/dense.py
+++ b/tfkan/layers/dense.py
@@ -122,7 +122,7 @@ class DenseKAN(Layer, LayerKAN):
     
     def _check_and_reshape_inputs(self, inputs):
         shape = tf.shape(inputs)
-        ndim = len(shape)
+        ndim = 2#len(shape)
         try:
             assert ndim >= 2
         except AssertionError:
@@ -217,7 +217,7 @@ class DenseKAN(Layer, LayerKAN):
             "spline_order": self.spline_order,
             "grid_range": self.grid_range,
             "spline_initialize_stddev": self.spline_initialize_stddev,
-            "basis_activation": self.basis_activation
+            "basis_activation": tf.keras.activations.serialize(self.basis_activation)
         })
 
         return config

--- a/tfkan/ops/spline.py
+++ b/tfkan/ops/spline.py
@@ -17,7 +17,7 @@ def calc_spline_values(x: tf.Tensor, grid: tf.Tensor, spline_order: int):
     Returns: tf.Tensor
         B-spline bases tensor of shape (batch_size, in_size, grid_size + spline_order).
     """
-    assert len(tf.shape(x)) == 2
+    #assert len(tf.shape(x)) == 2
     
     # add a extra dimension to do broadcasting with shape (batch_size, in_size, 1)
     x = tf.expand_dims(x, axis=-1)

--- a/tfkan/ops/spline.py
+++ b/tfkan/ops/spline.py
@@ -17,8 +17,7 @@ def calc_spline_values(x: tf.Tensor, grid: tf.Tensor, spline_order: int):
     Returns: tf.Tensor
         B-spline bases tensor of shape (batch_size, in_size, grid_size + spline_order).
     """
-    #assert len(tf.shape(x)) == 2
-    assert tf.size(tf.shape(x)) == 2
+    assert len(x.get_shape()) == 2
     
     # add a extra dimension to do broadcasting with shape (batch_size, in_size, 1)
     x = tf.expand_dims(x, axis=-1)

--- a/tfkan/ops/spline.py
+++ b/tfkan/ops/spline.py
@@ -18,6 +18,7 @@ def calc_spline_values(x: tf.Tensor, grid: tf.Tensor, spline_order: int):
         B-spline bases tensor of shape (batch_size, in_size, grid_size + spline_order).
     """
     #assert len(tf.shape(x)) == 2
+    assert tf.size(tf.shape(x)) == 2
     
     # add a extra dimension to do broadcasting with shape (batch_size, in_size, 1)
     x = tf.expand_dims(x, axis=-1)


### PR DESCRIPTION
Pros:
- Removed dimensionality assertions in all `_check_and_reshape_inputs` methods, since this was preventing saving models with KAN layers as TF Lite files, since they couldn't handle symbolic tensors
- When deserializing a Conv layer, a double rank argument was passed to the constructor by from_config, raising an error
- When serializing Dense, the basis_activation wasn't serialized correctly. Fixed this.
- All tests in 'demo' pass.

Cons:
- Removing the assertions makes the error messages (incase of incorrect dims) less clear, which is a down side that should be fixed